### PR TITLE
Don't force the attribute to be present.

### DIFF
--- a/lib/url_formatter/model_additions.rb
+++ b/lib/url_formatter/model_additions.rb
@@ -14,7 +14,7 @@ module UrlFormatter
       before_validation do
         send("#{attribute}=", UrlFormatter.format_url(send(attribute)))
       end
-      validates_format_of attribute, with: UrlFormatter.url_regexp, message: "is not a valid URL"
+      validates_format_of attribute, with: UrlFormatter.url_regexp, message: "is not a valid URL", if: "#{attribute}?"
     end
   end
 end

--- a/spec/url_formatter/model_additions_spec.rb
+++ b/spec/url_formatter/model_additions_spec.rb
@@ -19,4 +19,9 @@ describe UrlFormatter::ModelAdditions do
     comment.website = "example.com"
     comment.should be_valid
   end
+
+  it "allows a nil url to be valid" do
+    comment = Comment.new(website: nil)
+    comment.should be_valid
+  end
 end


### PR DESCRIPTION
For optional values this will make the object invalid because `nil` won't match the `UrlFormatter.url_regexp`.

This change will allow values to be optional...
